### PR TITLE
Use 32 bit client id for now

### DIFF
--- a/YDotNet/Document/Options/DocOptions.cs
+++ b/YDotNet/Document/Options/DocOptions.cs
@@ -10,7 +10,7 @@ public class DocOptions
     /// </summary>
     internal static DocOptions Default => new()
     {
-        Id = (ulong) Random.Shared.NextInt64(),
+        Id = (ulong) Random.Shared.Next(),
         ShouldLoad = true,
         Encoding = DocEncoding.Utf16
     };


### PR DESCRIPTION
yjs uses 32 bit client ids. If a client is exceeds the 32 range it cannot be decoded on the client anymore:

There is also an open discussion about that.
https://github.com/y-crdt/y-crdt/issues/209