### PR TITLE
Make the state vector optional in `Transaction.StateDiff*()` methods

### DIFF
--- a/Tests/YDotNet.Tests.Unit/Transactions/StateDiffV1Tests.cs
+++ b/Tests/YDotNet.Tests.Unit/Transactions/StateDiffV1Tests.cs
@@ -6,6 +6,20 @@ namespace YDotNet.Tests.Unit.Transactions;
 public class StateDiffV1Tests
 {
     [Test]
+    public void Null()
+    {
+        // Arrange
+        var senderDoc = ArrangeSenderDoc();
+
+        // Act
+        var stateDiff = senderDoc.ReadTransaction().StateDiffV1(stateVector: null);
+
+        // Assert
+        Assert.That(stateDiff, Is.Not.Null);
+        Assert.That(stateDiff, Has.Length.EqualTo(26));
+    }
+
+    [Test]
     public void ReadOnly()
     {
         // Arrange

--- a/Tests/YDotNet.Tests.Unit/Transactions/StateDiffV2Tests.cs
+++ b/Tests/YDotNet.Tests.Unit/Transactions/StateDiffV2Tests.cs
@@ -6,6 +6,20 @@ namespace YDotNet.Tests.Unit.Transactions;
 public class StateDiffV2Tests
 {
     [Test]
+    public void Null()
+    {
+        // Arrange
+        var senderDoc = ArrangeSenderDoc();
+
+        // Act
+        var stateDiff = senderDoc.ReadTransaction().StateDiffV2(stateVector: null);
+
+        // Assert
+        Assert.That(stateDiff, Is.Not.Null);
+        Assert.That(stateDiff, Has.Length.InRange(from: 37, to: 38));
+    }
+
+    [Test]
     public void ReadOnly()
     {
         // Arrange

--- a/YDotNet/Document/Transactions/Transaction.cs
+++ b/YDotNet/Document/Transactions/Transaction.cs
@@ -119,15 +119,15 @@ public class Transaction : IDisposable
     ///     </para>
     /// </remarks>
     /// <param name="stateVector">
-    ///     The state vector to be used as base for comparison and generation of the difference.
+    ///     The optional state vector to be used as base for comparison and generation of the difference.
     /// </param>
     /// <returns>
     ///     The lib0 v1 encoded state difference between the <see cref="Doc" /> of this <see cref="Transaction" /> and the
     ///     remote <see cref="Doc" />.
     /// </returns>
-    public byte[] StateDiffV1(byte[] stateVector)
+    public byte[] StateDiffV1(byte[]? stateVector)
     {
-        var handle = TransactionChannel.StateDiffV1(Handle, stateVector, (uint) stateVector.Length, out var length);
+        var handle = TransactionChannel.StateDiffV1(Handle, stateVector, (uint) (stateVector != null ? stateVector.Length : 0), out var length);
         var data = MemoryReader.ReadBytes(handle, length);
         BinaryChannel.Destroy(handle, length);
 
@@ -152,15 +152,15 @@ public class Transaction : IDisposable
     ///     </para>
     /// </remarks>
     /// <param name="stateVector">
-    ///     The state vector to be used as base for comparison and generation of the difference.
+    ///     The optional state vector to be used as base for comparison and generation of the difference.
     /// </param>
     /// <returns>
     ///     The lib0 v2 encoded state difference between the <see cref="Doc" /> of this <see cref="Transaction" /> and the
     ///     remote <see cref="Doc" />.
     /// </returns>
-    public byte[] StateDiffV2(byte[] stateVector)
+    public byte[] StateDiffV2(byte[]? stateVector)
     {
-        var handle = TransactionChannel.StateDiffV2(Handle, stateVector, (uint) stateVector.Length, out var length);
+        var handle = TransactionChannel.StateDiffV2(Handle, stateVector, (uint) (stateVector != null ? stateVector.Length : 0), out var length);
         var data = MemoryReader.ReadBytes(handle, length);
         BinaryChannel.Destroy(handle, length);
 

--- a/YDotNet/Document/Transactions/Transaction.cs
+++ b/YDotNet/Document/Transactions/Transaction.cs
@@ -127,7 +127,8 @@ public class Transaction : IDisposable
     /// </returns>
     public byte[] StateDiffV1(byte[]? stateVector)
     {
-        var handle = TransactionChannel.StateDiffV1(Handle, stateVector, (uint) (stateVector != null ? stateVector.Length : 0), out var length);
+        var stateVectorLength = stateVector?.Length ?? 0;
+        var handle = TransactionChannel.StateDiffV1(Handle, stateVector, (uint) stateVectorLength, out var length);
         var data = MemoryReader.ReadBytes(handle, length);
         BinaryChannel.Destroy(handle, length);
 
@@ -160,7 +161,8 @@ public class Transaction : IDisposable
     /// </returns>
     public byte[] StateDiffV2(byte[]? stateVector)
     {
-        var handle = TransactionChannel.StateDiffV2(Handle, stateVector, (uint) (stateVector != null ? stateVector.Length : 0), out var length);
+        var handle = TransactionChannel.StateDiffV2(
+            Handle, stateVector, (uint) (stateVector != null ? stateVector.Length : 0), out var length);
         var data = MemoryReader.ReadBytes(handle, length);
         BinaryChannel.Destroy(handle, length);
 

--- a/YDotNet/Document/Transactions/Transaction.cs
+++ b/YDotNet/Document/Transactions/Transaction.cs
@@ -161,8 +161,8 @@ public class Transaction : IDisposable
     /// </returns>
     public byte[] StateDiffV2(byte[]? stateVector)
     {
-        var handle = TransactionChannel.StateDiffV2(
-            Handle, stateVector, (uint) (stateVector != null ? stateVector.Length : 0), out var length);
+        var stateVectorLength = stateVector?.Length ?? 0;
+        var handle = TransactionChannel.StateDiffV2(Handle, stateVector, (uint) stateVectorLength, out var length);
         var data = MemoryReader.ReadBytes(handle, length);
         BinaryChannel.Destroy(handle, length);
 

--- a/YDotNet/Native/Transaction/TransactionChannel.cs
+++ b/YDotNet/Native/Transaction/TransactionChannel.cs
@@ -28,7 +28,7 @@ internal static class TransactionChannel
         EntryPoint = "ytransaction_state_diff_v1")]
     public static extern nint StateDiffV1(
         nint transaction,
-        byte[] stateVector,
+        byte[]? stateVector,
         uint stateVectorLength,
         out uint length);
 

--- a/YDotNet/Native/Transaction/TransactionChannel.cs
+++ b/YDotNet/Native/Transaction/TransactionChannel.cs
@@ -38,7 +38,7 @@ internal static class TransactionChannel
         EntryPoint = "ytransaction_state_diff_v2")]
     public static extern nint StateDiffV2(
         nint transaction,
-        byte[] stateVector,
+        byte[]? stateVector,
         uint stateVectorLength,
         out uint length);
 


### PR DESCRIPTION
The state vector is optional.