### PR TITLE
Revert "Use 32-bit number when generating random client IDs"

### DIFF
--- a/YDotNet/Document/Options/DocOptions.cs
+++ b/YDotNet/Document/Options/DocOptions.cs
@@ -10,7 +10,7 @@ public class DocOptions
     /// </summary>
     internal static DocOptions Default => new()
     {
-        Id = (ulong) Random.Shared.Next(),
+        Id = (ulong) Random.Shared.NextInt64(),
         ShouldLoad = true,
         Encoding = DocEncoding.Utf16
     };


### PR DESCRIPTION
Reverts LSViana/ydotnet#42 based on [this comment](https://github.com/LSViana/ydotnet/pull/42#issuecomment-1758621305).